### PR TITLE
Add prompt if `zet.public` not found

### DIFF
--- a/zet
+++ b/zet
@@ -36,6 +36,11 @@ _initialize() {
   : "${CONF[category.todo]:="TODO"}"
   : "${CONF[category.question]:="\\?"}"
   _config_write
+
+  if [[ ! -d "${CONF[zet.public]}" ]];then
+		echo "${CONF[zet.public]} (zet.public) does not exist.
+Create the directory or set zet.public using 'zet config'."
+  fi
 }
 
 _alternatives() {


### PR DESCRIPTION
Added a check using the `-d` bash conditional expression in the `_initialize()` function. If `${CONF[zet.public]}` does not exist, then tell user to create the directory, or change the value of `zet.public`. Unsure if the `_initialize()` function is the correct place for the check, and also unsure if wanting user to manually create directory or have `zet` do it. Keen to hear your thoughts @rwxrob. This resolves [issue #39](https://github.com/rwxrob/cmd-zet/issues/39).